### PR TITLE
correct association error for server.rb

### DIFF
--- a/app/models/server.rb
+++ b/app/models/server.rb
@@ -17,9 +17,11 @@ class Server < ApplicationRecord
         foreign_key: :creator_id,
         class_name: :User
 
-    has_many :joined_servers
+    has_many :joined_servers,
+        dependent: :destroy
 
     has_many :members,
         through: :joined_servers,
-        source: :member
+        source: :member,
+        dependent: :destroy
 end


### PR DESCRIPTION
- add `dependent: :destroy` to `has_many joined_servers`